### PR TITLE
Belleza en comandos

### DIFF
--- a/bot/commands/cm_date.js
+++ b/bot/commands/cm_date.js
@@ -3,7 +3,7 @@ module.exports = {
     descr: "Obtener la fecha actual en el servidor.",
     exec: (message, args) => {
         let date = new Date();
-        message.author.sendMessage("La fecha es `" + date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + "` en este servidor.");
+        message.author.sendEmbed({ description: "La fecha es `" + date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + "` en este servidor." });
         message.delete();
     }
 }

--- a/bot/commands/cm_date.js
+++ b/bot/commands/cm_date.js
@@ -3,7 +3,10 @@ module.exports = {
     descr: "Obtener la fecha actual en el servidor.",
     exec: (message, args) => {
         let date = new Date();
-        message.author.sendEmbed({ description: "La fecha es `" + date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + "` en este servidor." });
+        message.channel.sendEmbed({
+            description: "La fecha es `" + date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + "` en este servidor.",
+            color: 2527667
+        }, message.author.toString());
         message.delete();
     }
 }

--- a/bot/commands/cm_info.js
+++ b/bot/commands/cm_info.js
@@ -2,7 +2,7 @@ module.exports = {
     roles: ["@everyone"],
     descr: "Muestra el link de la repo del bot.",
     exec: (message, args) => {
-        message.author.sendMessage("Puedes ayudar aqui: https:\/\/github.com/mcmacker4/darkbot2");
+        message.author.sendEmbed({ description: "Puedes ayudar aqui: https:\/\/github.com/mcmacker4/darkbot2" });
         message.delete();
     }
 }

--- a/bot/commands/cm_info.js
+++ b/bot/commands/cm_info.js
@@ -2,7 +2,16 @@ module.exports = {
     roles: ["@everyone"],
     descr: "Muestra el link de la repo del bot.",
     exec: (message, args) => {
-        message.author.sendEmbed({ description: "Puedes ayudar aqui: https:\/\/github.com/mcmacker4/darkbot2" });
+        message.channel.sendEmbed({
+            "title": "Ayuda al desarrollo de Darkbot",
+            "description": "Si eres valiente o tienes una buena idea para el bot y quieres ayudar puedes hacerlo creando tu fork del [proyecto](https://github.com/mcmacker4/darkbot2) y publicando tu pull request especificando lo que has añadido/cambiado/arreglado o dando ideas [aqui](https://github.com/mcmacker4/darkbot2/issues).",
+            "url": "https://github.com/mcmacker4/darkbot2",
+            "color": 2527667,
+            "timestamp": "2017-03-07T18:09:25.144Z",
+            "thumbnail": {
+                "url": global.bot.user.displayAvatarURL
+            }
+        }, message.author.toString());
         message.delete();
     }
 }

--- a/bot/commands/cm_ping.js
+++ b/bot/commands/cm_ping.js
@@ -3,7 +3,7 @@ module.exports = {
     descr: "Pong!",
     exec: (message, args) => {
         let ping = Math.round(message.author.client.ping);
-        message.author.sendMessage(`Pong! (${ping}ms)`);
+        message.reply(`Pong! (${ping}ms)`).then(msg => msg.delete(5000));
         message.delete();
     }
 }

--- a/bot/commands/cm_prefix.js
+++ b/bot/commands/cm_prefix.js
@@ -9,7 +9,10 @@ module.exports = {
             message.guild.channels.find("name", "bienvenida")
                     .sendMessage("@everyone El prefijo de los comandos se ha cambiado a " + args[1]);
         } else {
-            message.author.sendEmbed({ description: "El prefijo tiene que ser uno de los siguientes caracteres: `" + punct.join(" ") + "`"});
+            message.author.sendEmbed({
+                description: "El prefijo tiene que ser uno de los siguientes caracteres: `" + punct.join(" ") + "`",
+                color: 2527667
+            });
         }
         message.delete();
     }

--- a/bot/commands/cm_prefix.js
+++ b/bot/commands/cm_prefix.js
@@ -1,0 +1,16 @@
+const punct = [",", "!", "?", "@", "#", "$", "%", "^", "&", "*"];
+
+module.exports = {
+    roles: ["[admin]"],
+    descr: "Cambiar el prefijo de los comandos.",
+    exec: (message, args) => {
+        if(args[1] && args[1].length == 1 && punct.includes(args[1])) {
+            global.config.prefix = args[1];
+            message.guild.channels.find("name", "bienvenida")
+                    .sendMessage("@everyone El prefijo de los comandos se ha cambiado a " + args[1]);
+        } else {
+            message.author.sendEmbed({ description: "El prefijo tiene que ser uno de los siguientes caracteres: `" + punct.join(" ") + "`"});
+        }
+        message.delete();
+    }
+}

--- a/bot/commands/cm_status.js
+++ b/bot/commands/cm_status.js
@@ -7,7 +7,10 @@ module.exports = {
         if(statuses.includes(args[1])) {
             global.bot.user.setStatus(args[1]);
         } else {
-            message.author.sendEmbed({ description: "El estado debe ser `online`, `idle`, `invisible` o `dnd` (do not disturb)." });
+            message.author.sendEmbed({
+                description: "El estado debe ser `online`, `idle`, `invisible` o `dnd` (do not disturb).",
+                color: 2527667
+            });
         }
         message.delete();
     }

--- a/bot/commands/cm_status.js
+++ b/bot/commands/cm_status.js
@@ -7,7 +7,7 @@ module.exports = {
         if(statuses.includes(args[1])) {
             global.bot.user.setStatus(args[1]);
         } else {
-            message.author.sendMessage("El estado debe ser `online`, `idle`, `invisible` o `dnd` (do not disturb).");
+            message.author.sendEmbed({ description: "El estado debe ser `online`, `idle`, `invisible` o `dnd` (do not disturb)." });
         }
         message.delete();
     }

--- a/bot/commands/cm_version.js
+++ b/bot/commands/cm_version.js
@@ -2,7 +2,7 @@ module.exports = {
     descr: "Devuelve la version actual del bot.",
     roles: ["@everyone"],
     exec: (message, args) => {
-        message.author.sendMessage(`El bot se encuentra en la versión ${global.config.version}`);
+        message.author.sendEmbed({ description: `El bot se encuentra en la versión ${global.config.version}` });
         message.delete();
     }
 }

--- a/bot/commands/cm_version.js
+++ b/bot/commands/cm_version.js
@@ -2,7 +2,10 @@ module.exports = {
     descr: "Devuelve la version actual del bot.",
     roles: ["@everyone"],
     exec: (message, args) => {
-        message.author.sendEmbed({ description: `El bot se encuentra en la versión ${global.config.version}` });
+        message.author.sendEmbed({
+            description: `Me encuentro en la versión ${global.config.version} ❤`,
+            color: 2527667
+        });
         message.delete();
     }
 }

--- a/bot/commands/commands.js
+++ b/bot/commands/commands.js
@@ -17,7 +17,7 @@ exports.list = {
         roles: ["@everyone"],
         descr: "Descripcion de los comandos disponibles.",
         exec: (message) => {
-            let embed = new Discord.RichEmbed();
+            let embed = new Discord.RichEmbed({ color: 2527667 });
             for(let cmd in exports.list) {
                 let command = exports.list[cmd];
                 if(hasPermission(command, message.member)) {

--- a/bot/commands/commands.js
+++ b/bot/commands/commands.js
@@ -21,7 +21,7 @@ exports.list = {
             for(let cmd in exports.list) {
                 let command = exports.list[cmd];
                 if(hasPermission(command, message.member)) {
-                    embed.addField(cmd, command.descr + " - " + command.roles.join());
+                    embed.addField(global.config.prefix + cmd, command.descr + " - " + command.roles.join());
                 }
             }
             message.author.sendEmbed(embed);


### PR DESCRIPTION
Todos los embeds de los comandos ahora tienen el color darkaqua.
Nuevo comando `prefix` para cambiar el prefijo de los comandos (`!` por defecto).
Comandos `date`, `info` y `ping` ahora dan el resultado en el mismo canal en lugar de por privado.
El comando `info` ahora es un gran texto con links.
El comando `date` ahora funciona.